### PR TITLE
Update pagination.html.twig

### DIFF
--- a/templates/partials/pagination.html.twig
+++ b/templates/partials/pagination.html.twig
@@ -5,7 +5,7 @@
 
 <ul class="pagination">
     {% if pagination.hasPrev %}
-        {% set url =  base_url ~ (pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
+        {% set url =  (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
         <li class="page-item">
             <a class="page-link" rel="prev" href="{{ url }}" aria-label="Previous">
                 <span aria-hidden="true">&laquo;</span>
@@ -27,7 +27,7 @@
                 <span class="sr-only">(current)</span>
             </li>
         {% elseif paginate.isInDelta %}
-            {% set url = base_url ~ (pagination.params ~ paginate.url)|replace({'//':'/'}) %}
+            {% set url = (base_url ~ pagination.params ~ paginate.url)|replace({'//':'/'}) %}
             <li class="page-item">
                 <a class="page-link" href="{{ url }}">
                     <span class="sr-only">Goes to Page</span>{{ paginate.number }}
@@ -41,7 +41,7 @@
 
     {% endfor %}
     {% if pagination.hasNext %}
-        {% set url = base_url ~ (pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
+        {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
         <li class="page-item">
             <a class="page-link" rel="next" href="{{ url }}" aria-label="Next">
                 <span aria-hidden="true">&raquo;</span>


### PR DESCRIPTION
Fix for an issue with broken pagination links.
Pagination URLs looked like <a class="page-link" href="//page:2"> — so they led to https://page:2 without base url.